### PR TITLE
Validation fix

### DIFF
--- a/lib/admin.py
+++ b/lib/admin.py
@@ -156,10 +156,11 @@ def set_info(page, form):
         elif form["action"] == "revalidate":
             try:
                 if form["studio"] == "__all__":
-                    studio_ids = list(scrape.Studio.objects().values_list("studio_id"))
+                    studio_ids = list(scrape.Studio.objects().values_list(
+                        "studio_id"))
                 else:
                     studio_ids = [int(form["studio"])]
-                
+
                 schema.revalidate_studios.delay(studio_ids)
                 return True
             except:

--- a/lib/admin.py
+++ b/lib/admin.py
@@ -153,6 +153,17 @@ def set_info(page, form):
                 return True
             except:
                 return False
+        elif form["action"] == "revalidate":
+            try:
+                if form["studio"] == "__all__":
+                    studio_ids = list(scrape.Studio.objects().values_list("studio_id"))
+                else:
+                    studio_ids = [int(form["studio"])]
+                
+                schema.revalidate_studios.delay(studio_ids)
+                return True
+            except:
+                return False
     elif page == "schemas":
         connect_db()
         if form["action"] == "delete":

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -248,7 +248,8 @@ def get_schema(schema_id, credentials_file=settings.DEFAULT_CREDENTIALS_FILE):
 
 
 @celery.decorators.task
-def revalidate_studios(studio_ids, credentials_file=settings.DEFAULT_CREDENTIALS_FILE):
+def revalidate_studios(studio_ids,
+                       credentials_file=settings.DEFAULT_CREDENTIALS_FILE):
     """Revalidates a studio against its schema.
 
     Args:
@@ -258,7 +259,7 @@ def revalidate_studios(studio_ids, credentials_file=settings.DEFAULT_CREDENTIALS
     Returns:
         None.
     """
-    
+
     connect_db(credentials_file=credentials_file)
 
     for studio_id in studio_ids:
@@ -275,7 +276,11 @@ def revalidate_studios(studio_ids, credentials_file=settings.DEFAULT_CREDENTIALS
 
         projects = scrape.Project.objects(studio_id=studio_id)
         for project in projects:
-            project["validation"][str(schema)] = validate_project(schema, project["project_id"], studio_id, credentials_file)
+            project["validation"][str(
+                schema)] = validate_project(schema,
+                                            project["project_id"],
+                                            studio_id,
+                                            credentials_file)
             project.save()
 
         studio["status"] = "complete"

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -1,5 +1,7 @@
 from . import common as common
 from datetime import datetime
+import celery.decorators
+import logging
 import mongoengine as mongo
 from mongoengine.queryset.visitor import Q
 
@@ -243,6 +245,37 @@ def get_schema(schema_id, credentials_file=settings.DEFAULT_CREDENTIALS_FILE):
         schema = dict()
 
     return schema
+
+
+@celery.decorators.task
+def revalidate_studios(studio_ids, credentials_file=settings.DEFAULT_CREDENTIALS_FILE):
+    """Revalidates a studio against its schema.
+
+    Args:
+        studio_ids (lst): The studio IDs to revalidate.
+        credentials_file (str): path to the database credentials file.
+
+    Returns:
+        None.
+    """
+    
+    connect_db(credentials_file=credentials_file)
+
+    for studio_id in studio_ids:
+        logging.info("Revalidating studio {}".format(studio_id))
+
+        studio = scrape.Studio.objects(studio_id=studio_id).first()
+        schema = studio["challenge_id"]
+
+        if schema is None:
+            continue
+
+        projects = scrape.Project.objects(studio_id=studio_id)
+        for project in projects:
+            project["validation"][str(schema)] = validate_project(schema, project["project_id"], studio_id, credentials_file)
+            project.save()
+
+    logging.info("Finished revalidating studios.")
 
 
 def validate_project(schema,

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -371,6 +371,6 @@ def validate_project(schema,
                      and result["min_instructions_length"]
                      and result["min_description_length"]
                      and -1 not in result["required_text"]
-                     and False not in result["required_blocks"])
+                     and True in result["required_blocks"])
 
     return result

--- a/lib/schema.py
+++ b/lib/schema.py
@@ -270,10 +270,16 @@ def revalidate_studios(studio_ids, credentials_file=settings.DEFAULT_CREDENTIALS
         if schema is None:
             continue
 
+        studio["status"] = "revalidating"
+        studio.save()
+
         projects = scrape.Project.objects(studio_id=studio_id)
         for project in projects:
             project["validation"][str(schema)] = validate_project(schema, project["project_id"], studio_id, credentials_file)
             project.save()
+
+        studio["status"] = "complete"
+        studio.save()
 
     logging.info("Finished revalidating studios.")
 

--- a/static/js/admin_studio.js
+++ b/static/js/admin_studio.js
@@ -39,6 +39,19 @@ let loaded = function() {
         }, type="form");
     };
 
+    // Page-specific event: revalidate studio
+    let revalidate = (event) => {
+        let identifier = event.target.dataset.identifier;
+        let data = {
+            "action": "revalidate",
+            "studio": identifier,
+            "schema": "__none__"
+        };
+        handle_ajax("POST", "/admin/studios", data, () => {
+            alert("Initiated revalidation.");
+        }, type="form");
+    };
+
     // Set page-specific events
     let page_events = function() {
         let choose_schema_buttons = document.querySelectorAll("[data-action='choose_schema']");
@@ -51,6 +64,12 @@ let loaded = function() {
         redownload_buttons.forEach(btn => {
             btn.removeEventListener("click", redownload);
             btn.addEventListener("click", redownload);
+        });
+
+        let revalidate_buttons = document.querySelectorAll("[data-action='revalidate']");
+        revalidate_buttons.forEach(btn => {
+            btn.removeEventListener("click", revalidate);
+            btn.addEventListener("click", revalidate);
         });
     };
     document.addEventListener("page_events", page_events);

--- a/static/js/admin_studio.js
+++ b/static/js/admin_studio.js
@@ -44,8 +44,7 @@ let loaded = function() {
         let identifier = event.target.dataset.identifier;
         let data = {
             "action": "revalidate",
-            "studio": identifier,
-            "schema": "__none__"
+            "studio": identifier
         };
         handle_ajax("POST", "/admin/studios", data, () => {
             alert("Initiated revalidation.");

--- a/templates/admin/studios.html
+++ b/templates/admin/studios.html
@@ -10,7 +10,8 @@
 
         <p>
             <a href="/studio">Add</a>&nbsp;&nbsp;
-            <a href="#" data-action="redownload" data-identifier="__all__">Redownload all</a>
+            <a href="#" data-action="redownload" data-identifier="__all__">Redownload all</a>&nbsp;&nbsp;
+            <a href="#" data-action="revalidate" data-identifier="__all__">Revalidate all</a>
         </p>
 
         <table class="table table-responsive-lg">
@@ -51,6 +52,7 @@
                         <a href="#" title="Choose prompt schema" data-action="choose_schema" data-identifier="{{ studio['studio_id'] }}" class="fa fa-link"></a>&nbsp;
                         <a href="#" title="Toggle public visibility" class="fa fa-globe" data-action="toggle_publicity" data-to="{{ not studio['public_show'] }}"></a>&nbsp;
                         <a href="#" title="Redownload" class="fa fa-cloud-download" data-action="redownload" data-identifier="{{ studio['studio_id'] }}"></a>&nbsp;
+                        <a href="#" title="Revalidate" class="fa fa-repeat" data-action="revalidate" data-identifier="{{ studio['studio_id'] }}"></a>&nbsp;
                         <a href="https://scratch.mit.edu/studios/{{ studio['studio_id'] }}" title="View on Scratch" class="fa fa-external-link" target="_blank"></a>&nbsp;
                         <a href="#" data-action="delete" data-identifier="{{ studio['studio_id'] }}" title="Delete" class="fa fa-trash"></a>
                     </td>

--- a/templates/admin/utilities.html
+++ b/templates/admin/utilities.html
@@ -14,8 +14,8 @@
     <div class="col-12">
         <a href="/certificate/generate" class="btn btn-primary">Generate certificates</a>
         <a href="/summary/generate" class="btn btn-primary">Generate summary page</a>
+        <a href="/cache/clear" class="btn btn-primary">Clear cache</a>
     </div>
-
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Fixes project validation by changing the `met` logic to need _any one_ of the required block options to be selected.

Also adds ability to revalidate projects without rescraping. Useful if changing the schema or if don't want the most recent version of studios from Scratch.